### PR TITLE
README: remove no-maintenance notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,3 @@
 A web application that converts [djot](https://github.com/jgm/djot) to HTML.
 
 Uses the latest Lua source code from the main branch (loaded directly from GitHub).
-
-> **Note**
-> No maintenance intended, feel free to fork.


### PR DESCRIPTION
To avoid confusion.

A note mentioning explicitly that this is a fork of the original playground could be added here, if desired.